### PR TITLE
Made the text in the search bar more appropriate

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <!-- Main Content -->
     <div class="container-fluid mt-5">
     <!-- Search Bar -->
-      <input class="container form-control" placeholder="Search for event here ...">
+      <input class="container form-control" placeholder="Search for an event here ...">
       <!-- Card Container -->
       <div class="card-container"></div>
       <!-- Card-Container Ends -->


### PR DESCRIPTION
# Description

#187 issue is fixed by me. I changed the text in the search bar, which is more grammatically correct.

![after](https://user-images.githubusercontent.com/69465191/111905976-6a592a80-8a74-11eb-95c6-86c0cbf73996.png)
![before](https://user-images.githubusercontent.com/69465191/111905977-6b8a5780-8a74-11eb-8f3d-4c6796a691fd.png)

