### PR TITLE
Changing "Select Event Status" to "All" in Status

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
         <div class="form-group">
           <label class="filter-labels">Status</label>
           <select class="form-control" id="event-status-filter" name="Event Status Filter">
-            <option value="All">Select Event Status</option>
+            <option value="All">All</option>
             <option value="Online">Online</option>
             <option value="Offline">Offline</option>
           </select>


### PR DESCRIPTION
# Description

The Select Event Status from the drop down menu on the top navigation bar is changes to All.
It was made else it would make a bit confusion for the user and may not expect the total experience

Fixes #241 (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings


## Screenshot
Please add screenshot of UI related changes if any, for further reference.
![Capture](https://user-images.githubusercontent.com/51394913/112744313-a5031b80-8fbc-11eb-846f-a9c8218c0aa8.PNG)

