### PR TITLE
navbar is visible now

### DIFF
--- a/Frontend/style.css
+++ b/Frontend/style.css
@@ -64,6 +64,7 @@ html {
   top: 13%;
   left: 0%;
   width: 85px;
+  margin-top: 98px;
   display: flex;
   flex-direction: column;
   z-index: 11;


### PR DESCRIPTION
Fixes # 385
The navbar and social media icons are overlapped , i have removed that issue
![Foss Events - Personal - Microsoft​ Edge 5_28_2021 11_35_26 AM](https://user-images.githubusercontent.com/69043944/119938174-77910a80-bf38-11eb-9769-3499d620651b.png)
